### PR TITLE
refactor: axios から fetch に移行する

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/jest": "30.0.0",
     "@types/node": "24.12.2",
     "@vercel/ncc": "0.38.4",
-    "axios": "1.15.0",
+
     "discord.js": "14.26.2",
     "eslint": "10.2.0",
     "eslint-config-standard": "17.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@vercel/ncc':
         specifier: 0.38.4
         version: 0.38.4
-      axios:
-        specifier: 1.15.0
-        version: 1.15.0
       discord.js:
         specifier: 14.26.2
         version: 14.26.2
@@ -1009,9 +1006,6 @@ packages:
 
   axios@1.14.0:
     resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
-
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   babel-jest@30.3.0:
     resolution: {integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==}
@@ -4010,14 +4004,6 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axios@1.14.0:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,4 @@
 import { Utils } from './utils'
-// axios import removed (migrated to fetch)
 
 describe('Utils', () => {
   describe('escape', () => {
@@ -115,21 +114,24 @@ describe('Utils', () => {
   })
 
   describe('translate', () => {
+    afterEach(() => jest.restoreAllMocks())
+
     it('should translate text using the specified GAS URL', async () => {
       const gasUrl = 'https://example.com/translate'
       const message = 'Hello, world!'
       const translatedMessage = 'こんにちは、世界！'
 
       // Mock fetch to return the translated message
-      globalThis.fetch = jest.fn().mockResolvedValueOnce({
+      jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({
-          response: {
-            result: translatedMessage,
-          },
-        }),
-      })
+        json: () =>
+          Promise.resolve({
+            response: {
+              result: translatedMessage,
+            },
+          }),
+      } as unknown as Response)
 
       const result = await Utils.translate(gasUrl, message)
       expect(result).toBe(translatedMessage)
@@ -140,11 +142,11 @@ describe('Utils', () => {
       const message = 'Hello, world!'
 
       // Mock fetch to return an error response
-      globalThis.fetch = jest.fn().mockResolvedValueOnce({
+      jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
         ok: false,
         status: 500,
-        json: async () => ({}),
-      })
+        json: () => Promise.resolve({}),
+      } as unknown as Response)
 
       const result = await Utils.translate(gasUrl, message)
       expect(result).toBeNull()

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { Utils } from './utils'
-import axios from 'axios'
+// axios import removed (migrated to fetch)
 
 describe('Utils', () => {
   describe('escape', () => {
@@ -120,14 +120,15 @@ describe('Utils', () => {
       const message = 'Hello, world!'
       const translatedMessage = 'こんにちは、世界！'
 
-      // Mock the axios.post method to return the translated message
-      jest.spyOn(axios, 'post').mockResolvedValueOnce({
+      // Mock fetch to return the translated message
+      globalThis.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
         status: 200,
-        data: {
+        json: async () => ({
           response: {
             result: translatedMessage,
           },
-        },
+        }),
       })
 
       const result = await Utils.translate(gasUrl, message)
@@ -138,9 +139,11 @@ describe('Utils', () => {
       const gasUrl = 'https://example.com/translate'
       const message = 'Hello, world!'
 
-      // Mock the axios.post method to return an error response
-      jest.spyOn(axios, 'post').mockResolvedValueOnce({
+      // Mock fetch to return an error response
+      globalThis.fetch = jest.fn().mockResolvedValueOnce({
+        ok: false,
         status: 500,
+        json: async () => ({}),
       })
 
       const result = await Utils.translate(gasUrl, message)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@book000/node-utils'
-import axios from 'axios'
+// axios import removed (migrated to fetch)
 
 interface TranslateResponse {
   response: {
@@ -129,30 +129,26 @@ export const Utils = {
     const logger = Logger.configure('Utils.translate')
 
     // Google Apps Scriptサービスに翻訳リクエストを送信
-    const response = await axios.post<TranslateResponse>(
-      gasUrl,
-      {
+    // fetch で GAS へ POST
+    const res = await fetch(gasUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      body: JSON.stringify({
         before,
         after,
         text: message,
         mode: 'html',
-      },
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Requested-With': 'XMLHttpRequest',
-        },
-      }
-    )
-
-    // レスポンスのステータスに応じて、翻訳が成功したかどうかを確認
-    if (response.status !== 200) {
-      logger.warn(`❌ メッセージの翻訳に失敗しました：${response.status}`)
+      }),
+    })
+    if (!res.ok) {
+      logger.warn(`❌ メッセージの翻訳に失敗しました：${res.status}`)
       return null
     }
-
-    // レスポンスから翻訳されたメッセージを返す
-    return response.data.response.result
+    const data = (await res.json()) as TranslateResponse
+    return data.response.result
   },
   /**
    * 改行されたテキストを指定された文字数制限内で分割する

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import { Logger } from '@book000/node-utils'
-// axios import removed (migrated to fetch)
 
 interface TranslateResponse {
   response: {
@@ -128,27 +127,33 @@ export const Utils = {
   ): Promise<string | null> {
     const logger = Logger.configure('Utils.translate')
 
-    // Google Apps Scriptサービスに翻訳リクエストを送信
-    // fetch で GAS へ POST
-    const res = await fetch(gasUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Requested-With': 'XMLHttpRequest',
-      },
-      body: JSON.stringify({
-        before,
-        after,
-        text: message,
-        mode: 'html',
-      }),
-    })
-    if (!res.ok) {
-      logger.warn(`❌ メッセージの翻訳に失敗しました：${res.status}`)
+    try {
+      // Google Apps Scriptサービスに翻訳リクエストを送信
+      const res = await fetch(gasUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify({
+          before,
+          after,
+          text: message,
+          mode: 'html',
+        }),
+      })
+      if (!res.ok) {
+        logger.warn(`❌ メッセージの翻訳に失敗しました：${res.status}`)
+        return null
+      }
+      const data = (await res.json()) as TranslateResponse
+      return data.response.result
+    } catch (error) {
+      logger.warn(
+        `❌ メッセージの翻訳中にエラーが発生しました：${String(error)}`
+      )
       return null
     }
-    const data = (await res.json()) as TranslateResponse
-    return data.response.result
   },
   /**
    * 改行されたテキストを指定された文字数制限内で分割する


### PR DESCRIPTION
fix book000/book000#102

axiosへの依存を削除し、ネイティブ fetch API に移行しました。

## 変更内容
- `axios` 依存を削除
- `fetch` API を使用するように変更
- 非2xxレスポンスに対するエラーハンドリングを追加