### PR TITLE
fix: TypeScript v6 対応のため tsconfig.json を修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "Node",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",
+    "rootDir": "./src",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,
@@ -22,6 +23,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "newLine": "LF",
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",
     "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "ts-node": { "files": true },
   "compilerOptions": {
     "target": "es2020",
-    "module": "commonjs",
-    "moduleResolution": "Node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",
     "rootDir": "./src",
@@ -23,12 +23,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
-    "newLine": "LF",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "newLine": "LF"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## 概要

Renovate PR #2246 (`chore(deps): update dependency typescript to v6`) の適用時に発生する以下のコンパイルエラーを解消します。

### 発生していたエラー

| エラーコード | 内容 |
|---|---|
| `TS5107` | `moduleResolution=node10` が TypeScript v6 で非推奨になった |
| `TS5101` | `baseUrl` が TypeScript v6 で非推奨になった |
| `TS5011` | `rootDir` が明示的に設定されていなかった |

## 変更内容

### `module` を `"commonjs"` → `"nodenext"` に変更、`moduleResolution` を `"Node"` → `"nodenext"` に変更

`moduleResolution: "Node"` は内部的に `node10` として扱われ、TypeScript v6 で非推奨エラー (TS5107) が発生します。
`moduleResolution: "nodenext"` は非推奨でなく、TypeScript v5・v6 両方で有効です。

`module: "nodenext"` + `moduleResolution: "nodenext"` の組み合わせでは `package.json` に `"type": "module"` がない場合は CommonJS 形式で出力されるため、既存の動作は維持されます。

### `baseUrl` と `paths` の削除

`baseUrl: "."` は TypeScript v6 で非推奨 (TS5101) となります。また、`paths` で定義していた `@/*` エイリアスはソースコード内で一切使用されていないことを確認したため、`baseUrl` と `paths` をまとめて削除しました。

### `rootDir: "./src"` の追加

TypeScript v6 では `rootDir` の明示的な設定が必須 (TS5011)。すべてのソースファイルが `src/` ディレクトリに配置されていることを確認した上で設定しています。

### `tsBuildInfoFile: "./dist/.tsbuildinfo"` の追加

`incremental` ビルドのキャッシュファイル (`tsconfig.tsbuildinfo`) がルートディレクトリに生成されると、CI の pnpm キャッシュ経由で復元された際に `clean` ステップで削除されず、ビルド結果の不整合が生じる問題を解消します。
`dist/.tsbuildinfo` に設定することで、`clean` スクリプト (`rimraf dist`) で確実に削除されるようになります。

## 検証

- TypeScript v5.9.3 (現行) で `tsc --noEmit` および `pnpm lint` がエラーなしで通ることを確認済み
- `pnpm run package` (clean + compile + packing) がエラーなしで完了することをローカルで確認済み
- `dist/main.js` が CommonJS 形式 (`require(...)`) で出力されることを確認済み
- コードレビュー実施済み (指摘事項なし)