### PR TITLE
fix: TypeScript v6.0 のビルドエラーを修正するため tsconfig.json に types を追加

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "newLine": "LF"
+    "newLine": "LF",
+    "types": ["node", "jest"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## 概要

TypeScript v6.0 へのアップグレード時に発生するビルドエラーを修正するため、`tsconfig.json` に `types` フィールドを追加しました。

Fixes #2417

## 変更内容

### `tsconfig.json`

`compilerOptions` に以下を追加:

```json
"types": ["node", "jest"]
```

## 背景

TypeScript v6.0 では、以前は自動的に読み込まれていた `@types` パッケージの自動読み込みがデフォルトで無効化されました。これにより、以下のエラーが発生していました:

- **TS2593**: `describe` が見つからない (Jest の型が読み込まれていない)
- **TS2304**: `expect` が見つからない (Jest の型が読み込まれていない)

## 対応

`tsconfig.json` の `compilerOptions` に `"types": ["node", "jest"]` を明示的に追加することで、Node.js グローバル (`process`、`__dirname`) および Jest グローバル (`describe`、`expect`) が正しく認識されるようになります。

## 確認事項

- [x] `pnpm install` 実行済み
- [x] `pnpm compile` (tsc) でビルドエラーなし
- [x] `pnpm lint` でリントエラーなし