### PR TITLE
fix: eslint-plugin-unicorn の新ルール違反を解消

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ export interface ConfigInterface {
   }
 }
 
-export class Configuration extends ConfigFramework<ConfigInterface> {
+export class Config extends ConfigFramework<ConfigInterface> {
   protected validates(): Record<string, (config: ConfigInterface) => boolean> {
     return {
       'discord is required': (config) => !!config.discord,

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,15 +1,15 @@
 import { Client, GatewayIntentBits, Partials } from 'discord.js'
 import { Logger } from '@book000/node-utils'
-import { Configuration } from './config'
+import { Config } from './config'
 import { EventHandler } from './event'
 
 export class Discord {
-  private config: Configuration
+  private config: Config
   public readonly client: Client
 
-  constructor(config: Configuration) {
+  constructor(config: Config) {
     const logger = Logger.configure('Discord.constructor')
-    this.client = new Client({
+    const client = new Client({
       intents: [
         GatewayIntentBits.Guilds,
         GatewayIntentBits.GuildMessages,
@@ -17,31 +17,42 @@ export class Discord {
       ],
       partials: [Partials.Message, Partials.Channel, Partials.User],
     })
-    this.client.on('ready', this.onReady.bind(this))
+    this.client = client
+    client.on('ready', this.onReady.bind(this))
 
-    const eventHandler = new EventHandler(this.client, config)
-    this.client.on('messageCreate', (message) => {
+    const eventHandler = new EventHandler(client, config)
+    client.on('messageCreate', (message) => {
       if (!message.inGuild()) {
         return
       }
-      eventHandler.onMessageCreate(message).catch((error: unknown) => {
-        logger.error('Failed to process message', error as Error)
-      })
+      ;(async () => {
+        try {
+          await eventHandler.onMessageCreate(message)
+        } catch (error) {
+          logger.error('Failed to process message', error as Error)
+        }
+      })()
     })
-    this.client.on('messageUpdate', (oldMessage, newMessage) => {
+    client.on('messageUpdate', (oldMessage, newMessage) => {
       if (!oldMessage.inGuild() || !newMessage.inGuild()) {
         return
       }
-      eventHandler
-        .onMessageUpdate(oldMessage, newMessage)
-        .catch((error: unknown) => {
+      ;(async () => {
+        try {
+          await eventHandler.onMessageUpdate(oldMessage, newMessage)
+        } catch (error) {
           logger.error('Failed to process message update', error as Error)
-        })
+        }
+      })()
     })
 
-    this.client.login(config.get('discord').token).catch((error: unknown) => {
-      Logger.configure('Discord').error('Failed to login', error as Error)
-    })
+    ;(async () => {
+      try {
+        await client.login(config.get('discord').token)
+      } catch (error) {
+        Logger.configure('Discord').error('Failed to login', error as Error)
+      }
+    })()
 
     this.config = config
   }

--- a/src/event.ts
+++ b/src/event.ts
@@ -6,16 +6,16 @@ import {
   PartialMessage,
   PermissionFlagsBits,
 } from 'discord.js'
-import { Configuration } from './config'
+import { Config } from './config'
 import { Logger } from '@book000/node-utils'
-import { Utils } from './utils'
+import { Utilities } from './utilities'
 import fs from 'node:fs'
 
 export class EventHandler {
   private client: Client
-  private config: Configuration
+  private config: Config
 
-  constructor(client: Client, config: Configuration) {
+  constructor(client: Client, config: Config) {
     this.client = client
     this.config = config
   }
@@ -52,11 +52,11 @@ export class EventHandler {
 
     // メッセージがpartialの場合は詳細を取得
     if (message.partial) {
-      const messageTemp = await message.fetch()
-      if (!messageTemp.inGuild()) {
+      const messageTemporary = await message.fetch()
+      if (!messageTemporary.inGuild()) {
         return
       }
-      message = messageTemp
+      message = messageTemporary
     }
     // チャンネルがテキストベースのチャンネルかつ、Guildチャンネルでない場合は無視
     if (!message.channel.isTextBased() || !message.inGuild()) {
@@ -94,8 +94,8 @@ export class EventHandler {
     const toLanguage = config.get('translate').toLanguage
 
     // メッセージを翻訳
-    const escapedText = Utils.escape(message.content)
-    const translatedMessage = await Utils.translate(
+    const escapedText = Utilities.escape(message.content)
+    const translatedMessage = await Utilities.translate(
       translateGasUrl,
       escapedText,
       fromLanguage,
@@ -105,7 +105,7 @@ export class EventHandler {
       logger.warn('❌ Failed to translate message')
       return
     }
-    const unescapedText = Utils.unescape(translatedMessage)
+    const unescapedText = Utilities.unescape(translatedMessage)
 
     // 翻訳前と翻訳後のメッセージが同じ場合は無視
     if (message.content === unescapedText) {
@@ -122,7 +122,7 @@ export class EventHandler {
 
     // 翻訳後のテキストが1900文字以上の場合は、1900文字を超える行から分割して送信
     // すでに送信したことがある場合は、メッセージを編集。ない場合は、メッセージを送信
-    const chunks = Utils.chunkedText(unescapedText, 1900)
+    const chunks = Utilities.chunkedText(unescapedText, 1900)
     const replies = await this.getReplies(message)
     const isRefreshed = await this.deleteMessagesIfAlreadyDeleted(replies)
     if (isRefreshed) {
@@ -140,15 +140,19 @@ export class EventHandler {
     this.saveReplies(message, newMessages)
 
     // 不要なメッセージを削除
-    const deleteMessages = replies.filter(
+    const messagesToDelete = replies.filter(
       (reply) =>
-        reply && !newMessages.some((message) => message.id === reply.id)
+        reply && newMessages.every((message) => message.id !== reply.id)
     )
-    const deletePromises = deleteMessages.map(async (reply) => {
+    const deletionPromises = messagesToDelete.map(async (reply) => {
       if (!reply) return
-      return await reply.delete().catch(() => null)
+      try {
+        return await reply.delete()
+      } catch {
+        return null
+      }
     })
-    await Promise.all(deletePromises)
+    await Promise.all(deletionPromises)
   }
 
   /**
@@ -173,7 +177,11 @@ export class EventHandler {
 
     const replyIds = data[message.id] ?? []
     const replyPromises = replyIds.map(async (id: string) => {
-      return await message.channel.messages.fetch(id).catch(() => null)
+      try {
+        return await message.channel.messages.fetch(id)
+      } catch {
+        return null
+      }
     })
     return Promise.all(replyPromises)
   }
@@ -206,7 +214,7 @@ export class EventHandler {
     messages: (Message<true> | null)[]
   ) {
     // 一つでもメッセージが存在しなかったら、すべてのメッセージを削除する
-    if (!messages.some((message) => !message)) {
+    if (messages.every(Boolean)) {
       return false
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
 import { Logger } from '@book000/node-utils'
-import { Configuration } from './config'
+import { Config } from './config'
 import { Discord } from './discord'
 
 function main() {
   const logger = Logger.configure('main')
-  const config = new Configuration('data/config.json')
+  const config = new Config('data/config.json')
   config.load()
   if (!config.validate()) {
     logger.error('❌ Configuration is invalid')
@@ -18,15 +18,15 @@ function main() {
   const discord = new Discord(config)
   process.once('SIGINT', () => {
     logger.info('👋 SIGINT signal received.')
-    discord
-      .close()
-      .then(() => {
+    ;(async () => {
+      try {
+        await discord.close()
         process.exit(0)
-      })
-      .catch((error: unknown) => {
+      } catch (error) {
         logger.error('Failed to close Discord client', error as Error)
         process.exit(1)
-      })
+      }
+    })()
   })
 }
 

--- a/src/utilities.test.ts
+++ b/src/utilities.test.ts
@@ -1,10 +1,10 @@
-import { Utils } from './utils'
+import { Utilities } from './utilities'
 
-describe('Utils', () => {
+describe('Utilities', () => {
   describe('escape', () => {
     it('should escape markdown links', () => {
       const text = 'Check out this link: <https://example.com>'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         'Check out this link: <span translate="no" data-type="url">https://example.com</span>'
       )
@@ -12,7 +12,7 @@ describe('Utils', () => {
 
     it('should escape code blocks', () => {
       const text = '```console.log("Hello, world!");```'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         '<span translate="no" data-type="code-block">console.log("Hello, world!");</span>'
       )
@@ -20,7 +20,7 @@ describe('Utils', () => {
 
     it('should escape inline code', () => {
       const text = '`escape`'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         '<span translate="no" data-type="code">escape</span>'
       )
@@ -28,7 +28,7 @@ describe('Utils', () => {
 
     it('should escape italic and bold formatting', () => {
       const text = '*italic* and **bold**'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         '<span translate="no" data-type="strong-or-italic">*</span>italic<span translate="no" data-type="strong-or-italic">*</span> and <span translate="no" data-type="strong-or-italic">**</span>bold<span translate="no" data-type="strong-or-italic">**</span>'
       )
@@ -36,7 +36,7 @@ describe('Utils', () => {
 
     it('should escape discord formatting', () => {
       const text = 'Check out this channel: <#123456789012345678>'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         'Check out this channel: <span translate="no" data-type="formatting"><#123456789012345678></span>'
       )
@@ -44,7 +44,7 @@ describe('Utils', () => {
 
     it('should escape custom emojis', () => {
       const text = 'Check out this emoji: <:name:123456789012345678>'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         'Check out this emoji: <span translate="no" data-type="formatting"><:name:123456789012345678></span>'
       )
@@ -52,7 +52,7 @@ describe('Utils', () => {
 
     it('should escape user mentions', () => {
       const text = 'Mentioning a user: <@123456789012345678>'
-      const escapedText = Utils.escape(text)
+      const escapedText = Utilities.escape(text)
       expect(escapedText).toBe(
         'Mentioning a user: <span translate="no" data-type="formatting"><@123456789012345678></span>'
       )
@@ -63,34 +63,34 @@ describe('Utils', () => {
     it('should unescape markdown links', () => {
       const text =
         'Check out this link: <span translate="no" data-type="url">https://example.com</span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe('Check out this link: <https://example.com>')
     })
 
     it('should unescape code blocks', () => {
       const text =
         '<span translate="no" data-type="code-block">console.log("Hello, world!");</span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe('```console.log("Hello, world!");```')
     })
 
     it('should unescape inline code', () => {
       const text = '<span translate="no" data-type="code">escape</span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe('`escape`')
     })
 
     it('should unescape italic and bold formatting', () => {
       const text =
         '<span translate="no" data-type="strong-or-italic">*</span>italic<span translate="no" data-type="strong-or-italic">*</span> and <span translate="no" data-type="strong-or-italic">**</span>bold<span translate="no" data-type="strong-or-italic">**</span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe('*italic* and **bold**')
     })
 
     it('should unescape discord formatting', () => {
       const text =
         'Check out this channel: <span translate="no" data-type="formatting"><#123456789012345678></span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe(
         'Check out this channel: <#123456789012345678>'
       )
@@ -99,7 +99,7 @@ describe('Utils', () => {
     it('should unescape custom emojis', () => {
       const text =
         'Check out this emoji: <span translate="no" data-type="formatting"><:name:123456789012345678></span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe(
         'Check out this emoji: <:name:123456789012345678>'
       )
@@ -108,7 +108,7 @@ describe('Utils', () => {
     it('should unescape user mentions', () => {
       const text =
         'Mentioning a user: <span translate="no" data-type="formatting"><@123456789012345678></span>'
-      const unescapedText = Utils.unescape(text)
+      const unescapedText = Utilities.unescape(text)
       expect(unescapedText).toBe('Mentioning a user: <@123456789012345678>')
     })
   })
@@ -133,7 +133,7 @@ describe('Utils', () => {
           }),
       } as unknown as Response)
 
-      const result = await Utils.translate(gasUrl, message)
+      const result = await Utilities.translate(gasUrl, message)
       expect(result).toBe(translatedMessage)
     })
 
@@ -148,7 +148,7 @@ describe('Utils', () => {
         json: () => Promise.resolve({}),
       } as unknown as Response)
 
-      const result = await Utils.translate(gasUrl, message)
+      const result = await Utilities.translate(gasUrl, message)
       expect(result).toBeNull()
     })
   })
@@ -162,7 +162,7 @@ describe('Utils', () => {
         'Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.',
         'Cras elementum ultrices diam.',
       ]
-      const chunks = Utils.chunkedText(texts.join('\n'), 30)
+      const chunks = Utilities.chunkedText(texts.join('\n'), 30)
       expect(chunks).toEqual([
         'Lorem ipsum dolor sit amet,',
         'consectetur adipiscing elit.',
@@ -176,14 +176,14 @@ describe('Utils', () => {
   })
 
   it('should empty array if the text is empty', () => {
-    const chunks = Utils.chunkedText('', 30)
+    const chunks = Utilities.chunkedText('', 30)
     expect(chunks).toEqual([])
   })
 
   it('should split the text into chunks', () => {
     const text =
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor. Cras elementum ultrices diam.'
-    const chunks = Utils.chunkedText(text, 30)
+    const chunks = Utilities.chunkedText(text, 30)
     expect(chunks).toEqual([
       'Lorem ipsum dolor sit amet, co',
       'nsectetur adipiscing elit. Sed',

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -6,7 +6,7 @@ interface TranslateResponse {
   }
 }
 
-export const Utils = {
+export const Utilities = {
   /**
    * テキストをエスケープするメソッド。MarkdownおよびDiscordのフォーマットをエスケープします。
    *
@@ -125,11 +125,11 @@ export const Utils = {
     before = 'en',
     after = 'ja'
   ): Promise<string | null> {
-    const logger = Logger.configure('Utils.translate')
+    const logger = Logger.configure('Utilities.translate')
 
     try {
       // Google Apps Scriptサービスに翻訳リクエストを送信
-      const res = await fetch(gasUrl, {
+      const response = await fetch(gasUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -142,11 +142,11 @@ export const Utils = {
           mode: 'html',
         }),
       })
-      if (!res.ok) {
-        logger.warn(`❌ メッセージの翻訳に失敗しました：${res.status}`)
+      if (!response.ok) {
+        logger.warn(`❌ メッセージの翻訳に失敗しました：${response.status}`)
         return null
       }
-      const data = (await res.json()) as TranslateResponse
+      const data = (await response.json()) as TranslateResponse
       return data.response.result
     } catch (error) {
       logger.warn(


### PR DESCRIPTION
## 概要
Renovate PR #2439（`@book000/eslint-config` を v1.15.44 へ更新）で新たに有効化される `eslint-plugin-unicorn` のルールが、既存コード中の pre-existing なスタイル違反を検知して Node CI が failing になっています。本 PR は、その eslint-config の更新自体には触れず、検知された違反のみをこの PR で先行して解消します。

## 変更内容
- `unicorn/name-replacements`: `Configuration` -> `Config`、`Utils` -> `Utilities`、`messageTemp` -> `messageTemporary`、`res` -> `response`。あわせて `src/utils.ts` / `src/utils.test.ts` を `src/utilities.ts` / `src/utilities.test.ts` にリネーム
- `unicorn/prefer-await`: `.then()`/`.catch()` チェーンを `try`/`await`/`catch` に変換（非 async のイベントリスナー内は無名 async IIFE でラップ）
- `unicorn/no-non-function-verb-prefix`: `deleteMessages`/`deletePromises` を `messagesToDelete`/`deletionPromises` にリネーム
- `unicorn/no-negated-array-predicate` は `eslint --fix` で自動修正

## 動作確認
- `pnpm run lint`（prettier + eslint + tsc）: 現行の `@book000/eslint-config@1.15.4` および PR #2439 が導入する `1.15.44` の両方でクリーンであることを確認（`package.json`/`pnpm-lock.yaml` は変更していません）
- `pnpm test`: 19 件すべて成功
